### PR TITLE
Correct docblock definition in Currency::filter method

### DIFF
--- a/src/INGDiBa/Filter/Currency.php
+++ b/src/INGDiBa/Filter/Currency.php
@@ -36,7 +36,7 @@ class Currency implements FilterInterface
 
     /**
      * Filter a currency value
-     * @param string $value
+     * @param mixed $value
      * @return string
      */
     public function filter($value)


### PR DESCRIPTION
While seemingly trivial, the previous value may be misleading. This was
picked up by phpstan. This change helps ensure greater readability and
reduce errors.Correct docblock definition in Currency::filter method

While seemingly trivial, the previous value may be misleading. This was
picked up by phpstan. This change helps ensure greater readability and
reduce errors.