### PR TITLE
Ensure that the filter method returns an integer

### DIFF
--- a/src/Filter/Currency/CurrencyStringToInteger.php
+++ b/src/Filter/Currency/CurrencyStringToInteger.php
@@ -66,7 +66,7 @@ class CurrencyStringToInteger implements FilterInterface
             $fraction = str_pad($fraction, 2, '0', STR_PAD_RIGHT);
         }
 
-        return str_replace('.', '', $integer) . $fraction;
+        return intval(str_replace('.', '', $integer) . $fraction);
     }
 
     /**

--- a/test/Filter/Currency/CurrencyStringToIntegerTest.php
+++ b/test/Filter/Currency/CurrencyStringToIntegerTest.php
@@ -23,12 +23,14 @@ class CurrencyStringToIntegerTest extends TestCase
     public function testCanCorrectlyFilterInputData($testData, $validData)
     {
         $filter = new CurrencyStringToInteger();
-        $this->assertEquals($validData, $filter->filter($testData));
+        $this->assertSame($validData, $filter->filter($testData));
     }
 
     public function dataProvider()
     {
         return [
+            ['-0,55', -55],
+            ['0,55', 55],
             ['1,01', 101],
             ['1,2', 120],
             ['1,', 100],


### PR DESCRIPTION
I'm not sure how this slipped through, but the method, up until this
point, was returning a string, not an integer. Perhaps it was because of
the evolving nature of the project, perhaps it was an oversight.
Regardless, this change ensures that the method only returns an integer
value.